### PR TITLE
Removed a broken link

### DIFF
--- a/tensorflow/g3doc/tutorials/deep_cnn/index.md
+++ b/tensorflow/g3doc/tutorials/deep_cnn/index.md
@@ -206,8 +206,6 @@ with a learning rate that
 [exponentially decays](../../api_docs/python/train.md#exponential_decay)
 over time.
 
-![CIFAR-10 Learning Rate Decay](../../images/cifar_lr_decay.png "CIFAR-10 Learning Rate Decay")
-
 The `train()` function adds the operations needed to minimize the objective by
 calculating the gradient and updating the learned variables (see
 [`GradientDescentOptimizer`](../../api_docs/python/train.md#GradientDescentOptimizer)


### PR DESCRIPTION
A broken link referred to CIFAR-10 learning rate decay which was a broken link. So, I removed the link and the references to the link.
